### PR TITLE
Fix upload for MEME and fix svgref->getsvgref (take 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "brace": "^0.11.1",
     "color-name-list": "^4.10.0",
     "copy-to-clipboard": "^3.2.0",
-    "logos-to-go-react": "^0.1.14",
+    "logos-to-go-react": "^0.2.4",
     "react": "^16.8.6",
     "react-ace": "^7.0.2",
     "react-color": "^2.17.3",

--- a/src/components/svgdownload/button.jsx
+++ b/src/components/svgdownload/button.jsx
@@ -6,8 +6,8 @@ const _dodownload = ( svgref, filename ) => {
     downloadSVG(svgref, filename);
 };
 
-const SVGDownloadButton = ({ children, svgref, filename }) => (
-    <span onClick={ () => _dodownload(svgref, filename) }>
+const SVGDownloadButton = ({ children, getsvgref, filename }) => (
+    <span onClick={ () => _dodownload(getsvgref(), filename) }>
       {children}
     </span>
 );

--- a/src/components/svgdownload/copybutton.jsx
+++ b/src/components/svgdownload/copybutton.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
+import copy from 'copy-to-clipboard';
 
 import { _svgdata } from './utils';
 
-const SVGCopyButton = ({ children, svgref }) => (
-    <CopyToClipboard text={_svgdata(ReactDOM.findDOMNode(svgref))}>
-      <span>
+const SVGCopyButton = ({ children, getsvgref }) => (
+      <span onClick={() => copy(_svgdata(getsvgref()))}>
 	{children}
       </span>
-    </CopyToClipboard>
 );
 export default SVGCopyButton;

--- a/src/components/workspace/fastaworkspace/fastaworkspace.jsx
+++ b/src/components/workspace/fastaworkspace/fastaworkspace.jsx
@@ -86,6 +86,7 @@ class FastaWorkspace extends React.Component {
 
     constructor(props) {
 	super(props);
+	this.logo = React.createRef();
 	this.logoPostUrl = apiUrls(props.apiserver).logo("");
 	this.state = {
 	    fasta: DNADEFAULT,
@@ -164,7 +165,9 @@ class FastaWorkspace extends React.Component {
 	this.setState({
 	    mode: data.value
 	});
-    }
+	}
+
+	getsvgref = () => this.logo.current;
     
     render() {
 	let pwm = fastaToPWM(this.state.fasta, this.state.glyphmap.lookup, this.state.caseinsensitive);
@@ -208,9 +211,9 @@ class FastaWorkspace extends React.Component {
 		      </Grid.Row>
 	              <Grid.Row style={{ height: '60%' }}>
 			<Grid.Column width={16} style={{ height: '100%' }}>
-		          <FastaLogoMenu svgref={this.logo} logoinfo={this._format_logoinfo(this.state, pwm)}
+		          <FastaLogoMenu getsvgref={this.getsvgref} logoinfo={this._format_logoinfo(this.state, pwm)}
 				         apiurl={this.logoPostUrl} />
-		          <div ref={ c => { this.logo = c; } }
+		          <div ref={this.logo}
                                style={{ height: '75%', textAlign: "center" }}>
                             <Logo pwm={pwm}
 			          startpos={this.state.startpos}

--- a/src/components/workspace/fastaworkspace/menu.jsx
+++ b/src/components/workspace/fastaworkspace/menu.jsx
@@ -7,17 +7,17 @@ const ITEMSTYLE = {
     labelsize: "10pt",
 };
 
-const FastaLogoMenu = ({ svgref, apiurl, logoinfo }) => (
+const FastaLogoMenu = ({ getsvgref, apiurl, logoinfo }) => (
     <LogoMenu width="100%" background="#d0d0d0">
       <LogoSVGDownloadButton {...ITEMSTYLE}
-			     labeltext="Save" svgref={svgref}
+			     labeltext="Save" getsvgref={getsvgref}
 			     filename="logo.svg" />
       <LogoSVGCopyButton {...ITEMSTYLE}
-			 labeltext="Copy SVG" svgref={svgref} />
+			 labeltext="Copy SVG" getsvgref={getsvgref} />
       <PermalinkButton {...ITEMSTYLE} labeltext="permalink"
 		       url={apiurl} logoinfo={logoinfo} />
       <EmbedButton {...ITEMSTYLE} labeltext="embed"
-		   url={apiurl} logoinfo={logoinfo} />
+		   url={apiurl} logoinfo={logoinfo} getsvgref={getsvgref}  />
     </LogoMenu>
 );
 export default FastaLogoMenu;

--- a/src/components/workspace/menu/embedbutton.jsx
+++ b/src/components/workspace/menu/embedbutton.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 
+import { _svgdata } from '../../svgdownload/utils';
 import { CopyTextButton } from './copytextmodal/index';
 
 const INSTRUCTIONS = "To embed your logo in a webpage, simply copy this HTML tag"
       + " and paste it in the desired location:";
 
-const EmbedButton = ({ url, logoinfo, labelsize, labeltext, iconsize }) => (
-    <CopyTextButton url={url} options={ { body: JSON.stringify(logoinfo) } }
-		    dataformatter={ data => '<img src="' + url + data.uuid + '">' } iconclass="code"
+const EmbedButton = ({ getsvgref, url, logoinfo, labelsize, labeltext, iconsize }) => (
+    <CopyTextButton url={url} options={ { body: JSON.stringify(logoinfo) } } data={getsvgref}
+		    dataformatter={ data => `<img src="data:image/svg+xml;base64,${Buffer.from(_svgdata(data())).toString("base64")}">` } iconclass="code"
                     iconsize={iconsize} labelsize={labelsize} labeltext={labeltext}
                     modalheader="Embed code generated!" additionaltext={INSTRUCTIONS} />
 );

--- a/src/components/workspace/menu/svgcopybutton.jsx
+++ b/src/components/workspace/menu/svgcopybutton.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Icon, Menu } from 'semantic-ui-react';
 import { SVGCopyButton } from '../../svgdownload/index';
 
-const LogoSVGCopyButton = ({ svgref, iconsize, labelsize, labeltext }) => (
+const LogoSVGCopyButton = ({ getsvgref, iconsize, labelsize, labeltext }) => (
     <Menu.Item link>
-      <SVGCopyButton svgref={svgref}>
+      <SVGCopyButton getsvgref={getsvgref}>
 	<Icon className="copy outline" style={{ color: "#000", fontSize: iconsize }} /><br />
 	<div style={{ fontSize: labelsize, color: "#000" }}>{labeltext}</div>
       </SVGCopyButton>

--- a/src/components/workspace/menu/svgdownloadbutton.jsx
+++ b/src/components/workspace/menu/svgdownloadbutton.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Icon, Menu } from 'semantic-ui-react';
 import { SVGDownloadButton } from '../../svgdownload/index';
 
-const LogoSVGDownloadButton = ({ svgref, filename, iconsize, labelsize, labeltext }) => (
+const LogoSVGDownloadButton = ({ getsvgref, filename, iconsize, labelsize, labeltext }) => (
     <Menu.Item link>
-      <SVGDownloadButton svgref={svgref} filename={filename}>
+      <SVGDownloadButton getsvgref={getsvgref} filename={filename}>
 	<Icon className="download" style={{ color: "#000", fontSize: iconsize }} /><br />
 	<div style={{ fontSize: labelsize, color: "#000" }}>{labeltext}</div>
       </SVGDownloadButton>

--- a/src/components/workspace/pwmworkspace/menu.jsx
+++ b/src/components/workspace/pwmworkspace/menu.jsx
@@ -8,17 +8,17 @@ const ITEMSTYLE = {
     labelsize: "10pt",
 };
 
-const PWMLogoMenu = ({ svgref, apiurl, logoinfo }) => (
+const PWMLogoMenu = ({ getsvgref, apiurl, logoinfo }) => (
     <LogoMenu width="100%" background="#d0d0d0">
       <LogoSVGDownloadButton {...ITEMSTYLE}
-			     labeltext="Save" svgref={svgref}
+			     labeltext="Save" getsvgref={getsvgref}
 			     filename="logo.svg" />
       <LogoSVGCopyButton {...ITEMSTYLE}
-			 labeltext="Copy SVG" svgref={svgref} />
+			 labeltext="Copy SVG" getsvgref={getsvgref} />
       <PermalinkButton {...ITEMSTYLE} labeltext="permalink"
 		       url={apiurl} logoinfo={logoinfo} />
       <EmbedButton {...ITEMSTYLE} labeltext="embed"
-		   url={apiurl} logoinfo={logoinfo} />
+		   url={apiurl} logoinfo={logoinfo} getsvgref={getsvgref}  />
     </LogoMenu>
 );
 export default PWMLogoMenu;

--- a/src/components/workspace/pwmworkspace/pwmworkspace.jsx
+++ b/src/components/workspace/pwmworkspace/pwmworkspace.jsx
@@ -24,6 +24,7 @@ class PWMWorkspace extends React.Component {
 
     constructor(props) {
 	super(props);
+	this.logo = React.createRef();
 	this.logoPostUrl = apiUrls(props.apiserver).logo("");
 	this.state = {
 	    pwm: {
@@ -113,7 +114,9 @@ class PWMWorkspace extends React.Component {
 	this.setState({
 	    mode: data.value
 	});
-    }
+	}
+
+	getsvgref = () => this.logo.current;
     
     render() {
 	let hasNegative = this.state.pwm && this.state.pwm.parsed && this.state.pwm.parsed.length && anyNegative(this.state.pwm.parsed);
@@ -155,9 +158,9 @@ class PWMWorkspace extends React.Component {
 		      </Grid.Row>
 	              <Grid.Row style={{ height: '60%' }}>
 			<Grid.Column width={16} style={{ height: "100%" }}>
-			  <PWMLogoMenu svgref={this.logo} apiurl={this.logoPostUrl}
+			  <PWMLogoMenu getsvgref={this.getsvgref} apiurl={this.logoPostUrl}
 				       logoinfo={this._format_logoinfo(this.state)} />
-			  <div ref={ c => { this.logo = c; } }
+			  <div ref={this.logo}
                             style={{ height: "75%", textAlign: "center" }}>
 			    { hasNegative ? (
 				<LogoWithNegatives pwm={this.state.pwm.parsed}

--- a/src/components/workspace/uploadworkspace/anyupload.jsx
+++ b/src/components/workspace/uploadworkspace/anyupload.jsx
@@ -139,7 +139,7 @@ class AnyUploadWorkspace extends React.Component {
                 inmotif = true;
             else if (line.startsWith("MOTIF"))
                 cmotifname = line.split("MOTIF ")[1];
-            else if (inmotif && !line.startsWith(' ')) {
+            else if (inmotif && line.trim().length === 0) {
                 inmotif = false;
                 pwms.push({ pwm: cpwm });
                 motifnames.push(cmotifname);

--- a/src/components/workspace/uploadworkspace/menu.jsx
+++ b/src/components/workspace/uploadworkspace/menu.jsx
@@ -8,17 +8,17 @@ const ITEMSTYLE = {
     labelsize: "10pt",
 };
 
-const UploadLogoMenu = ({ svgref, apiurl, logoinfo }) => (
+const UploadLogoMenu = ({ getsvgref, apiurl, logoinfo }) => (
     <LogoMenu width="100%">
       <LogoSVGDownloadButton {...ITEMSTYLE}
-			     labeltext="Save" svgref={svgref}
+			     labeltext="Save" getsvgref={getsvgref}
 			     filename="logo.svg" />
       <LogoSVGCopyButton {...ITEMSTYLE}
-			 labeltext="Copy SVG" svgref={svgref} />
+			 labeltext="Copy SVG" getsvgref={getsvgref} />
       <PermalinkButton {...ITEMSTYLE} labeltext="permalink"
 		       url={apiurl} logoinfo={logoinfo} />
       <EmbedButton {...ITEMSTYLE} labeltext="embed"
-		   url={apiurl} logoinfo={logoinfo} />
+		   url={apiurl} logoinfo={logoinfo} getsvgref={getsvgref}  />
     </LogoMenu>
 );
 export default UploadLogoMenu;

--- a/src/components/workspace/uploadworkspace/uploadworkspace.jsx
+++ b/src/components/workspace/uploadworkspace/uploadworkspace.jsx
@@ -22,8 +22,9 @@ const LOGOCOMPONENTS = {
 class UploadWorkspace extends React.Component {
 
     constructor(props) {
-	super(props);
+    super(props);
 	this.logoPostUrl = apiUrls(props.apiserver).logo("");
+    this.logo = React.createRef();
 	this.state = {
 	    pwms: [],
             errors: [],
@@ -100,6 +101,8 @@ class UploadWorkspace extends React.Component {
 	    mode: data.value
 	});
     }
+
+    getsvgref = () => this.logo.current;
     
     async parseFile(f) {
         const reader = new FileReader();
@@ -247,9 +250,9 @@ class UploadWorkspace extends React.Component {
                                                    selectedmotif={this.state.selectedmotif}
                                                    onItemSelected={this.onItemSelected.bind(this)} />
 			          </div>
-                                <LogoMenu svgref={this.logo} apiurl={this.logoPostUrl}
+                                <LogoMenu getsvgref={this.getsvgref} apiurl={this.logoPostUrl}
 				              logoinfo={this._format_logoinfo(this.state)} />
-			        <div ref={ c => { this.logo = c; } }
+			        <div ref={this.logo}
                                      style={{ height: "75%", textAlign: "center" }}>
 			          <Logo pwm={selectedPWMs.result.pwms[this.state.selectedmotif].pwm}
 				        startpos={0}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6124,16 +6124,14 @@ loglevel@^1.4.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
 
-logos-to-go-react@^0.1.14:
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/logos-to-go-react/-/logos-to-go-react-0.1.14.tgz#6a393cc1a5be7c0e6e93b25301322f1a93ef02ef"
-  integrity sha512-Dn8668XZ0L4apoWUylfYuzmuSScsbzWwNc9Fh/AfHIOvVJcFQS6TW24V0bsIR4gx1iXyfo7AGFRqjdEtmpdlwA==
+logos-to-go-react@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/logos-to-go-react/-/logos-to-go-react-0.2.4.tgz#f1d1e895b7da10d8293a9b4488c318cdd8d6252d"
+  integrity sha512-hoNHRdykzqVvwn4AnQ08jSvvd+88PwgrJKj9WTE2hEau8UhrpVY/QTs/8ugvGgcNAvrt5mX0jrrCdU7vqwK0wA==
   dependencies:
     babel-cli "^6.26.0"
     babel-preset-es2015 "^6.24.1"
     babel-preset-react "^6.24.1"
-    react "^16.3.1"
-    react-dom "^16.3.1"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -8047,7 +8045,7 @@ react-dev-utils@^9.0.1:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dom@^16.3.1, react-dom@^16.8.6:
+react-dom@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   dependencies:
@@ -8173,7 +8171,7 @@ react-syntax-highlighter@^11.0.2:
     prismjs "^1.8.4"
     refractor "^2.4.1"
 
-react@^16.3.1, react@^16.8.6:
+react@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   dependencies:


### PR DESCRIPTION
Take 2. Tried to keep diff minimal to make rebases/merges easier.

- Updated logos-to-go-react version. Fresh installs fail otherwise.

- Fix meme parsing again. This isn't 100% correct still because it relies on there being an empty line between motifs. Really though, should only roll to next motif on "MOTIF" (http://meme-suite.org/doc/meme-format.html). A space at the beginning of pwm lines isn't required.

- Fix Embed/Copy buttons. The Embed button hadn't been updated to not expect api request data. The copy button wasn't working because components aren't reloaded after refs are set, so svgref is being passed as undefined. IMO, the embed button only makes sense if there's actually an api server (otherwise it's more or less a different form of copy), but I didn't do anything other than fix this by using base64 encoded svg data.
